### PR TITLE
Switch to using dkms modules to provide support for nvidia-peermem

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for ansible_role_nvidia
 
-nvidia_driver_branch: 535
+nvidia_driver_branch: 570-dkms
 
 nvidia_driver_nvml_package_name: libnvidia-ml  # used to be nvidia-driver-NVML before 560 series
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
   - name: install precompiled nvidia drivers from rpm repository
     ansible.builtin.dnf:
       name:
+        - "kmod-nvidia-latest-dkms{{ '-' + nvidia_driver_version if nvidia_driver_version is defined else '' }}"
         - "nvidia-driver{{ '-' + nvidia_driver_version if nvidia_driver_version is defined else '' }}"
         - "nvidia-driver-cuda{{ '-' + nvidia_driver_version if nvidia_driver_version is defined else '' }}"
         - "nvidia-fabric-manager{{ '-' + nvidia_driver_version if nvidia_driver_version is defined else '' }}" # this is needed for our H200s Will be enabled by an ww4 overlay.


### PR DESCRIPTION
This PR switches from non-dkms to dkms branch for nvidia-peermem support.